### PR TITLE
Adds the ability to match on missing components.

### DIFF
--- a/Sources/MyNameIsURL/Matchers/Host.swift
+++ b/Sources/MyNameIsURL/Matchers/Host.swift
@@ -22,8 +22,23 @@ public struct Host: URLMatchable {
   }
   
 
+  /**
+   A value that matches a `URL` with a `host` property of `nil`.
+   
+   Usage:
+   ```
+   let host = URL(string: "http://example.com")!
+   let noHost = URL(string: "http://")!
+   Host.missing.matches(url: host)   //> false
+   Host.missing.matches(url: noHost) //> true
+   ```
+   */
   public static let missing: URLMatchable = Missing()
+  
+  
   private let host: String
+  
+  
   /**
    Wraps the given string to create a new `Host` value. It matches `URL`s based on their `host` property.
    

--- a/Sources/MyNameIsURL/Matchers/Host.swift
+++ b/Sources/MyNameIsURL/Matchers/Host.swift
@@ -45,8 +45,6 @@ public struct Host: URLMatchable {
    - SeeAlso: `HostSuffix`
    
    - Parameter host: The host to match. It will be compared for equality against `URL`’s `host` property.
-   
-     This value will be compared for equality against `URL`’s `host` property.
    */
   public init(_ host: String) {
     self.host = host

--- a/Sources/MyNameIsURL/Matchers/Host.swift
+++ b/Sources/MyNameIsURL/Matchers/Host.swift
@@ -15,6 +15,14 @@ import Foundation
  - SeeAlso: `HostSuffix`
 */
 public struct Host: URLMatchable {
+  private struct Missing: URLMatchable {
+    public func matches(url: URL) -> Bool {
+      return url.host == nil
+    }
+  }
+  
+
+  public static let missing: URLMatchable = Missing()
   private let host: String
   /**
    Wraps the given string to create a new `Host` value. It matches `URL`s based on their `host` property.

--- a/Sources/MyNameIsURL/Matchers/Password.swift
+++ b/Sources/MyNameIsURL/Matchers/Password.swift
@@ -9,7 +9,29 @@ public struct Password: URLMatchable {
     }
   }
     
+  
+  /**
+   A value that matches a `URL` with a `password` property of `nil`.
+   
+   RFC 1738 (and this package) makes a distinction between *empty* (`""`) passwords and *no* (`nil`) passwords:
+   
+   > Note that an empty user name or password is different than no user name or password.
+   
+   As such, this value only matches against no (`nil`) passwords. In practice this is a pretty meaningless distinction because please-god-don’t-put-auth-info-in-your-URLs. But if there is occation to match an *empty* password, one can use `Password("")` to achieve that purpose.
+   
+   Usage:
+   ```
+   let password = URL(string: "http://user:pass@example.com")!
+   let emptyPassword = URL(string: "http://user:@example.com")!
+   let noPassword = URL(string: "http://example.com")!
+   Password.missing.matches(url: password)      //> false
+   Password.missing.matches(url: emptyPassword) //> false
+   Password.missing.matches(url: noPassword)    //> true
+   ```
+   */
   public static let missing: URLMatchable = Missing()
+  
+  
   private let password: String
   
   

--- a/Sources/MyNameIsURL/Matchers/Password.swift
+++ b/Sources/MyNameIsURL/Matchers/Password.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+
+
+public struct Password: URLMatchable {
+  private struct Missing: URLMatchable {
+    func matches(url: URL) -> Bool {
+      return url.password == nil
+    }
+  }
+    
+  public static let missing: URLMatchable = Missing()
+  private let password: String
+  
+  
+  public init(_ password: String ) {
+    self.password = password
+  }
+  
+  
+  public func matches(url: URL) -> Bool {
+    return url.password == password
+  }
+}

--- a/Sources/MyNameIsURL/Matchers/Password.swift
+++ b/Sources/MyNameIsURL/Matchers/Password.swift
@@ -2,6 +2,19 @@ import Foundation
 
 
 
+/**
+ Type that matches a `URL` based on comparison with the `URL`’s `password` propery.
+ 
+ Usage:
+ ```
+ let url = URL(string: "https://user:pass@example.com")!
+ Password("pass").matches(url) //> true
+ ```
+ 
+ - Note: RFC 1738 makes a distinction between *empty* (`""`) passwords and *no* (`nil`) passwords. In the uncommon case you need to match a URL with an *empty* password (*i.e.* “http://foo:@example.com”), create a `Password` with an empty string: `Password("")`. The much more common *no* password can be matched with `Password.missing`.
+ 
+ - SeeAlso: `User`, `Password.missing`
+ */
 public struct Password: URLMatchable {
   private struct Missing: URLMatchable {
     func matches(url: URL) -> Bool {
@@ -35,11 +48,25 @@ public struct Password: URLMatchable {
   private let password: String
   
   
+  /**
+   Wraps the given string to create a new `Password` value. It matches `URL`s based on their `password` property.
+   
+   - SeeAlso: `User`
+   
+   - Parameter password: The password to match. It will be compared for equality against `URL`’s `password` property.
+   */
   public init(_ password: String ) {
     self.password = password
   }
   
   
+  /**
+   Predicate that determines whether a `Password` matches a given `URL`.
+   
+   - Parameter url: The `URL` to be matched.
+   
+   - Returns: `true` if the wrapped password is equivalent to `url.password`. Otherwise, `false`.
+   */
   public func matches(url: URL) -> Bool {
     return url.password == password
   }

--- a/Sources/MyNameIsURL/Matchers/Path.swift
+++ b/Sources/MyNameIsURL/Matchers/Path.swift
@@ -22,8 +22,25 @@ public struct Path: URLMatchable {
   }
   
   
+  /**
+   A value that matches a `URL` whose `path` property is an empty string (`""`).
+   
+   Usage:
+   ```
+   let path = URL(string: "http://example.com/foo")!
+   let slash = URL(string: "http://example.com/")!
+   let noPath = URL(string: "http://exmaple.com")!
+   Path.missing.matches(url: path)   //> false
+   Path.missing.matches(url: slash)  //> false
+   Path.missing.matches(url: noPath) //> true
+   ```
+   */
   public static let missing: URLMatchable = Missing()
+  
+  
   private let path: String
+  
+  
   /**
    Wraps the given string to create a new `Path` value. It matches `URL`s based on their `path` property.
    

--- a/Sources/MyNameIsURL/Matchers/Path.swift
+++ b/Sources/MyNameIsURL/Matchers/Path.swift
@@ -15,6 +15,14 @@ import Foundation
  - SeeAlso: `PathPrefix`
  */
 public struct Path: URLMatchable {
+  private struct Missing: URLMatchable {
+    func matches(url: URL) -> Bool {
+      return url.path == ""
+    }
+  }
+  
+  
+  public static let missing: URLMatchable = Missing()
   private let path: String
   /**
    Wraps the given string to create a new `Path` value. It matches `URL`s based on their `path` property.

--- a/Sources/MyNameIsURL/Matchers/Port.swift
+++ b/Sources/MyNameIsURL/Matchers/Port.swift
@@ -2,6 +2,15 @@ import Foundation
 
 
 
+/**
+ Type that matches a `URL` based on comparison with the `URL`’s `port` propery.
+ 
+ Usage:
+ ```
+ let url = URL(string: "https://example.com:8080")!
+ Port(8080).matches(url) //> true
+ ```
+ */
 public struct Port: URLMatchable {
   private struct Missing: URLMatchable {
     public func matches(url: URL) -> Bool {
@@ -22,14 +31,28 @@ public struct Port: URLMatchable {
    ```
    */
   public static let missing: URLMatchable = Missing()
+
+
   private let port: Int
   
   
+  /**
+   Wraps the given number to create a new `Port` value. It matches `URL`s based on their `port` property.
+   
+   - Parameter port: The port number to match. It will be compared for equality against `URL`’s `port` property.
+   */
   public init(_ port: Int) {
     self.port = port
   }
   
   
+  /**
+   Predicate that determines whether a `Port` matches a given `URL`.
+   
+   - Parameter url: The `URL` to be matched.
+   
+   - Returns: `true` if the wrapped port number is equivalent to `url.port`. Otherwise, `false`.
+   */
   public func matches(url: URL) -> Bool {
     return url.port == port
   }

--- a/Sources/MyNameIsURL/Matchers/Port.swift
+++ b/Sources/MyNameIsURL/Matchers/Port.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+
+
+public struct Port: URLMatchable {
+  private struct Missing: URLMatchable {
+    public func matches(url: URL) -> Bool {
+      return url.port == nil
+    }
+  }
+
+
+  public static let missing: URLMatchable = Missing()
+  private let port: Int
+  
+  
+  public init(_ port: Int) {
+    self.port = port
+  }
+  
+  
+  public func matches(url: URL) -> Bool {
+    return url.port == port
+  }
+}
+
+
+

--- a/Sources/MyNameIsURL/Matchers/Port.swift
+++ b/Sources/MyNameIsURL/Matchers/Port.swift
@@ -10,6 +10,17 @@ public struct Port: URLMatchable {
   }
 
 
+  /**
+   A value that matches a `URL` with a `port` property of `nil`.
+   
+   Usage:
+   ```
+   let port = URL(string: "http://example.com:8080")!
+   let noPort = URL(string: "http://example.com")!
+   Port.missing.matches(url: port)   //> false
+   Port.missing.matches(url: noPort) //> true
+   ```
+   */
   public static let missing: URLMatchable = Missing()
   private let port: Int
   

--- a/Sources/MyNameIsURL/Matchers/Scheme+URLMatchable.swift
+++ b/Sources/MyNameIsURL/Matchers/Scheme+URLMatchable.swift
@@ -6,7 +6,7 @@ import Foundation
  Extends `Scheme` to match the `scheme` a URL.
  */
 extension Scheme: URLMatchable {
-  public static var missing: URLMatchable { Missing() }
+  public static var missing: URLMatchable { return Missing() }
 
 
   /**

--- a/Sources/MyNameIsURL/Matchers/Scheme+URLMatchable.swift
+++ b/Sources/MyNameIsURL/Matchers/Scheme+URLMatchable.swift
@@ -6,6 +6,9 @@ import Foundation
  Extends `Scheme` to match the `scheme` a URL.
  */
 extension Scheme: URLMatchable {
+  public static var missing: URLMatchable { Missing() }
+
+
   /**
    Predicate that determines whether a `Scheme` matches a given `URL`.
    
@@ -14,5 +17,15 @@ extension Scheme: URLMatchable {
    */
   public func matches(url: URL) -> Bool {
     return url.scheme == value
+  }
+}
+
+
+
+private extension Scheme {
+  struct Missing: URLMatchable {
+    func matches(url: URL) -> Bool {
+      return url.scheme == nil
+    }
   }
 }

--- a/Sources/MyNameIsURL/Matchers/User.swift
+++ b/Sources/MyNameIsURL/Matchers/User.swift
@@ -10,6 +10,25 @@ public struct User: URLMatchable {
   }
   
   
+  /**
+   A value that matches a `URL` with a `user` property of `nil`.
+   
+   RFC 1738 (and this package) makes a distinction between *empty* (`""`) users and *no* (`nil`) users:
+   
+   > Note that an empty user name or password is different than no user name or password.
+   
+   As such, this value only matches against no (`nil`) users. In practice this is a pretty meaningless distinction because please-god-don’t-put-auth-info-in-your-URLs. But if there is occation to match an *empty* user, one can use `User("")` to achieve that purpose.
+   
+   Usage:
+   ```
+   let user = URL(string: "http://user:pass@example.com")!
+   let emptyUser = URL(string: "http://@example.com")!
+   let noUser = URL(string: "http://example.com")!
+   User.missing.matches(url: user)      //> false
+   User.missing.matches(url: emptyUser) //> false
+   User.missing.matches(url: noUser)    //> true
+   ```
+   */
   public static let missing: URLMatchable = Missing()
   private let user: String
   

--- a/Sources/MyNameIsURL/Matchers/User.swift
+++ b/Sources/MyNameIsURL/Matchers/User.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+
+
+public struct User: URLMatchable {
+  private struct Missing: URLMatchable {
+    func matches(url: URL) -> Bool {
+      return url.user == nil
+    }
+  }
+  
+  
+  public static let missing: URLMatchable = Missing()
+  private let user: String
+  
+  
+  public init(_ user: String) {
+    self.user = user
+  }
+  
+  
+  public func matches(url: URL) -> Bool {
+    return url.user == user
+  }
+}

--- a/Sources/MyNameIsURL/Matchers/User.swift
+++ b/Sources/MyNameIsURL/Matchers/User.swift
@@ -2,6 +2,19 @@ import Foundation
 
 
 
+/**
+ Type that matches a `URL` based on comparison with the `URL`’s `user` propery.
+ 
+ Usage:
+ ```
+ let url = URL(string: "https://user:pass@example.com")!
+ User("user").matches(url) //> true
+ ```
+ 
+ - Note: RFC 1738 makes a distinction between *empty* (`""`) users and *no* (`nil`) users. In the uncommon case you need to match a URL with an *empty* user name (*i.e.* “http://@example.com”), create a `User` with an empty string: `User("")`. The much more common *no* user can be matched with `User.missing`.
+ 
+ - SeeAlso: `Password`, `User.missing`
+ */
 public struct User: URLMatchable {
   private struct Missing: URLMatchable {
     func matches(url: URL) -> Bool {
@@ -30,14 +43,30 @@ public struct User: URLMatchable {
    ```
    */
   public static let missing: URLMatchable = Missing()
+  
+  
   private let user: String
   
   
+  /**
+   Wraps the given string to create a new `User` value. It matches `URL`s based on their `user` property.
+   
+   - SeeAlso: `Password`
+   
+   - Parameter user: The user name to match. It will be compared for equality against `URL`’s `user` property.
+   */
   public init(_ user: String) {
     self.user = user
   }
   
   
+  /**
+   Predicate that determines whether a `User` matches a given `URL`.
+   
+   - Parameter url: The `URL` to be matched.
+   
+   - Returns: `true` if the wrapped user name is equivalent to `url.user`. Otherwise, `false`.
+   */
   public func matches(url: URL) -> Bool {
     return url.user == user
   }

--- a/Support/MyNameIsURL.xcodeproj/project.pbxproj
+++ b/Support/MyNameIsURL.xcodeproj/project.pbxproj
@@ -51,6 +51,15 @@
 		C12354CF22D90855007EC78D /* URLSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12354CE22D90855007EC78D /* URLSchemeTests.swift */; };
 		C190154722E2253F00FADA9D /* Scheme+URLMatchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C190154622E2253F00FADA9D /* Scheme+URLMatchable.swift */; };
 		C190154922E2342C00FADA9D /* String+HostComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C190154822E2342C00FADA9D /* String+HostComponents.swift */; };
+		C19DE70123106F8B00782334 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19DE70023106F8B00782334 /* User.swift */; };
+		C19DE7032310727C00782334 /* Factory+User.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19DE7022310727C00782334 /* Factory+User.swift */; };
+		C19DE70523107AA400782334 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19DE70423107AA400782334 /* UserTests.swift */; };
+		C1A0E64823109DF600339C86 /* Password.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0E64723109DF600339C86 /* Password.swift */; };
+		C1A0E64A23109EA500339C86 /* Factory+Password.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0E64923109EA500339C86 /* Factory+Password.swift */; };
+		C1A0E64C23109F7600339C86 /* PasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0E64B23109F7600339C86 /* PasswordTests.swift */; };
+		C1AE2755230DA84B0099C39C /* Port.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AE2754230DA84B0099C39C /* Port.swift */; };
+		C1AE2757230DA9E10099C39C /* PortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AE2756230DA9E10099C39C /* PortTests.swift */; };
+		C1AE2759230DAA310099C39C /* Factory+Port.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AE2758230DAA310099C39C /* Factory+Port.swift */; };
 		OBJ_21 /* URLMatchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* URLMatchable.swift */; };
 		OBJ_28 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_41 /* MyNameIsURL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "MyNameIsURL::MyNameIsURL::Product" /* MyNameIsURL.framework */; };
@@ -104,6 +113,15 @@
 		C12354CE22D90855007EC78D /* URLSchemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeTests.swift; sourceTree = "<group>"; };
 		C190154622E2253F00FADA9D /* Scheme+URLMatchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Scheme+URLMatchable.swift"; sourceTree = "<group>"; };
 		C190154822E2342C00FADA9D /* String+HostComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+HostComponents.swift"; sourceTree = "<group>"; };
+		C19DE70023106F8B00782334 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		C19DE7022310727C00782334 /* Factory+User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Factory+User.swift"; sourceTree = "<group>"; };
+		C19DE70423107AA400782334 /* UserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
+		C1A0E64723109DF600339C86 /* Password.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Password.swift; sourceTree = "<group>"; };
+		C1A0E64923109EA500339C86 /* Factory+Password.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Factory+Password.swift"; sourceTree = "<group>"; };
+		C1A0E64B23109F7600339C86 /* PasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordTests.swift; sourceTree = "<group>"; };
+		C1AE2754230DA84B0099C39C /* Port.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Port.swift; sourceTree = "<group>"; };
+		C1AE2756230DA9E10099C39C /* PortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortTests.swift; sourceTree = "<group>"; };
+		C1AE2758230DAA310099C39C /* Factory+Port.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Factory+Port.swift"; sourceTree = "<group>"; };
 		"MyNameIsURL::MyNameIsURL::Product" /* MyNameIsURL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MyNameIsURL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"MyNameIsURL::MyNameIsURLTests::Product" /* MyNameIsURLTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = MyNameIsURLTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -146,7 +164,10 @@
 				C110EC2822CD1268007FF845 /* HostSuffix.swift */,
 				C110EC2A22CD1371007FF845 /* Path.swift */,
 				C110EC2D22CD13C8007FF845 /* PathPrefix.swift */,
+				C1AE2754230DA84B0099C39C /* Port.swift */,
 				C190154622E2253F00FADA9D /* Scheme+URLMatchable.swift */,
+				C19DE70023106F8B00782334 /* User.swift */,
+				C1A0E64723109DF600339C86 /* Password.swift */,
 				C110EC2F22CD141D007FF845 /* And.swift */,
 				C110EC3122CD1476007FF845 /* Or.swift */,
 				C110EC3322CD149E007FF845 /* Not.swift */,
@@ -173,6 +194,9 @@
 				C110EC3C22CD3860007FF845 /* Factory+Path.swift */,
 				C110EC5422CFAB03007FF845 /* Factory+PathPrefix.swift */,
 				C110EC4022CD9A43007FF845 /* Factory+Scheme.swift */,
+				C1AE2758230DAA310099C39C /* Factory+Port.swift */,
+				C19DE7022310727C00782334 /* Factory+User.swift */,
+				C1A0E64923109EA500339C86 /* Factory+Password.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -200,6 +224,9 @@
 				C110EC4C22CE312D007FF845 /* NotTests.swift */,
 				C110EC5622CFAE8F007FF845 /* PatternOperatorTests.swift */,
 				C12354CE22D90855007EC78D /* URLSchemeTests.swift */,
+				C1AE2756230DA9E10099C39C /* PortTests.swift */,
+				C19DE70423107AA400782334 /* UserTests.swift */,
+				C1A0E64B23109F7600339C86 /* PasswordTests.swift */,
 			);
 			name = MyNameIsURLTests;
 			path = Tests/MyNameIsURLTests;
@@ -334,10 +361,13 @@
 				C110EC3422CD149E007FF845 /* Not.swift in Sources */,
 				C110EC2B22CD1371007FF845 /* Path.swift in Sources */,
 				C110EC4522CD9BC4007FF845 /* Scheme.swift in Sources */,
+				C1AE2755230DA84B0099C39C /* Port.swift in Sources */,
 				C110EC3022CD141D007FF845 /* And.swift in Sources */,
+				C19DE70123106F8B00782334 /* User.swift in Sources */,
 				C110EC2922CD1268007FF845 /* HostSuffix.swift in Sources */,
 				C110EC2E22CD13C8007FF845 /* PathPrefix.swift in Sources */,
 				C190154722E2253F00FADA9D /* Scheme+URLMatchable.swift in Sources */,
+				C1A0E64823109DF600339C86 /* Password.swift in Sources */,
 				C110EC1B22CD08D6007FF845 /* Domain.swift in Sources */,
 				C110EC2422CD0D05007FF845 /* Host.swift in Sources */,
 				C110EC3222CD1476007FF845 /* Or.swift in Sources */,
@@ -366,14 +396,20 @@
 				C110EC4722CD9C81007FF845 /* AndTests.swift in Sources */,
 				C110EC3622CD1558007FF845 /* HostTests.swift in Sources */,
 				C110EC5122CF9725007FF845 /* HostSuffixTests.swift in Sources */,
+				C1A0E64A23109EA500339C86 /* Factory+Password.swift in Sources */,
 				C110EC4D22CE312D007FF845 /* NotTests.swift in Sources */,
+				C1A0E64C23109F7600339C86 /* PasswordTests.swift in Sources */,
 				C110EC4B22CE3018007FF845 /* OrTests.swift in Sources */,
 				C110EC5722CFAE8F007FF845 /* PatternOperatorTests.swift in Sources */,
 				C110EC4322CD9B3B007FF845 /* SchemeTests.swift in Sources */,
 				C110EC3B22CD37CE007FF845 /* Factory+Host.swift in Sources */,
 				C110EC3D22CD3860007FF845 /* Factory+Path.swift in Sources */,
+				C19DE70523107AA400782334 /* UserTests.swift in Sources */,
+				C1AE2757230DA9E10099C39C /* PortTests.swift in Sources */,
+				C1AE2759230DAA310099C39C /* Factory+Port.swift in Sources */,
 				C110EC3922CD3142007FF845 /* Factory.swift in Sources */,
 				C110EC4922CE2ED9007FF845 /* Factory+DomainName.swift in Sources */,
+				C19DE7032310727C00782334 /* Factory+User.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/MyNameIsURLTests/AndTests.swift
+++ b/Tests/MyNameIsURLTests/AndTests.swift
@@ -7,9 +7,23 @@ import MyNameIsURL
 class AndTests: XCTestCase {
   let subject = And(
     Factory.Scheme.success,
+    Factory.User.success,
+    Factory.Password.success,
     Factory.Host.success,
-    Factory.Path.success)
+    Factory.Path.success,
+    Factory.Port.success)
 
+  
+  let nilSubject = And(
+    Scheme.missing,
+    User.missing,
+    Password.missing,
+    Host.missing,
+    Port.missing,
+    Path.missing
+  )
+  
+  
   func testSuccess() {
     XCTAssert(subject.matches(url: Factory.url))
     XCTAssertFalse(subject.matches(url: Factory.nilURL))
@@ -25,5 +39,11 @@ class AndTests: XCTestCase {
     
     let badPath = URL(string: "http://www.example.com/foo/baz")!
     XCTAssertFalse(subject.matches(url: badPath))
+  }
+  
+  
+  func testNil() {
+    XCTAssert(nilSubject.matches(url: Factory.nilURL))
+    XCTAssertFalse(nilSubject.matches(url: Factory.url))
   }
 }

--- a/Tests/MyNameIsURLTests/HostTests.swift
+++ b/Tests/MyNameIsURLTests/HostTests.swift
@@ -11,6 +11,7 @@ class HostTests: XCTestCase {
   
   
   func testNil() {
+    XCTAssert(Host.missing.matches(url: Factory.nilURL))
     XCTAssertFalse(Factory.Host.success.matches(url: Factory.nilURL))
   }
 

--- a/Tests/MyNameIsURLTests/OrTests.swift
+++ b/Tests/MyNameIsURLTests/OrTests.swift
@@ -7,8 +7,11 @@ import MyNameIsURL
 class OrTests: XCTestCase {
   let subject = Or(
     Factory.Scheme.success,
+    Factory.User.success,
+    Factory.Password.success,
     Factory.Host.success,
-    Factory.Path.success)
+    Factory.Path.success,
+    Factory.Port.success)
   
   func testSuccess() {
     XCTAssert(subject.matches(url: Factory.url))
@@ -31,11 +34,20 @@ class OrTests: XCTestCase {
 
     let badSchemeAndPath = URL(string: "https://www.example.com/foo/baz")!
     XCTAssert(subject.matches(url: badSchemeAndPath))
+    
+    let onlyGoodPort = URL(string: "foo://nothing.test:80/foo/baz")!
+    XCTAssert(subject.matches(url: onlyGoodPort))
+    
+    let onlyGoodUser = URL(string: "foo://please@nothing.test:64/nothing")!
+    XCTAssert(subject.matches(url: onlyGoodUser))
+
+    let onlyGoodPassword = URL(string: "foo://foo:don't@nothing.test:64/nothing")!
+    XCTAssert(subject.matches(url: onlyGoodPassword))
   }
   
   
   func testFailure() {
-    let badSchemeAndHostAndPath = URL(string: "https://www2.example.com/foo/baz")!
+    let badSchemeAndHostAndPath = URL(string: "https://foo:bar@www2.example.com:48/foo/baz")!
     XCTAssertFalse(subject.matches(url: badSchemeAndHostAndPath))
   }
 }

--- a/Tests/MyNameIsURLTests/PasswordTests.swift
+++ b/Tests/MyNameIsURLTests/PasswordTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import MyNameIsURL
+
+
+
+class PasswordTests: XCTestCase {
+  func testSuccess() {
+    XCTAssert(Factory.Password.success.matches(url: Factory.url))
+    XCTAssertFalse(Factory.Password.success.matches(url: Factory.nilURL))
+  }
+  
+  
+  func testNil() {
+    XCTAssertFalse(Password.missing.matches(url: Factory.url))
+    XCTAssert(Password.missing.matches(url: Factory.nilURL))
+  }
+  
+  
+  func testBlankPassword() {
+    let subject = URL(string: "http://foo:@example.com")!
+    XCTAssert(Password("").matches(url: subject))
+  }
+  
+  
+  func testUserWithMissingPassword() {
+    let subject = URL(string: "http://foo@example.com")!
+    XCTAssert(Password.missing.matches(url: subject))
+  }
+}

--- a/Tests/MyNameIsURLTests/PathTests.swift
+++ b/Tests/MyNameIsURLTests/PathTests.swift
@@ -10,7 +10,8 @@ class PathTests: XCTestCase {
   }
   
   
-  func testNoNilMatches() {
+  func testNilMatches() {
+    XCTAssert(Path.missing.matches(url: Factory.nilURL))
     XCTAssertFalse(Factory.Path.success.matches(url: Factory.nilURL))
   }
   

--- a/Tests/MyNameIsURLTests/PortTests.swift
+++ b/Tests/MyNameIsURLTests/PortTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import MyNameIsURL
+
+
+
+class PortTests: XCTestCase {
+  func testSuccess() {
+    XCTAssert(Factory.Port.success.matches(url: Factory.url))
+    Factory.Port.failures.forEach {
+      XCTAssertFalse($0.matches(url: Factory.url))
+    }
+  }
+
+  
+  func testNil() {
+    XCTAssert(Port.missing.matches(url: Factory.nilURL))
+  }
+  
+  
+  func testURLDoesNotDefault() {
+    let defaultHTTPPort = URL(string: "http://example.com")!
+    XCTAssertFalse(Factory.Port.success.matches(url: defaultHTTPPort))
+    XCTAssert(Port.missing.matches(url: defaultHTTPPort))
+  }
+  
+  
+  func testLeadingZeroes() {
+    let leadingZeroes = URL(string: "http://example.com:0080")!
+    XCTAssert(Factory.Port.success.matches(url: leadingZeroes))
+  }
+}

--- a/Tests/MyNameIsURLTests/SchemeTests.swift
+++ b/Tests/MyNameIsURLTests/SchemeTests.swift
@@ -123,6 +123,7 @@ class SchemeTests: XCTestCase {
     }
     XCTAssert(Factory.Scheme.success.matches(url: Factory.url))
     XCTAssertFalse(Factory.Scheme.success.matches(url: Factory.nilURL))
+    XCTAssert(Scheme.missing.matches(url: Factory.nilURL))
   }
 }
 

--- a/Tests/MyNameIsURLTests/Support/Factory+Password.swift
+++ b/Tests/MyNameIsURLTests/Support/Factory+Password.swift
@@ -1,0 +1,23 @@
+import Foundation
+import MyNameIsURL
+
+
+
+extension Factory {
+  enum Password {
+    static let success = MyNameIsURL.Password("don't")
+    
+    static let failures = [
+      MyNameIsURL.Password(":"),
+      MyNameIsURL.Password("@"),
+      MyNameIsURL.Password("don't:"),
+      MyNameIsURL.Password("don't@"),
+      MyNameIsURL.Password(":don't"),
+      MyNameIsURL.Password("@don't"),
+      MyNameIsURL.Password(" "),
+      MyNameIsURL.Password(""),
+      MyNameIsURL.Password(" don't"),
+      MyNameIsURL.Password("don't "),
+    ]
+  }
+}

--- a/Tests/MyNameIsURLTests/Support/Factory+Port.swift
+++ b/Tests/MyNameIsURLTests/Support/Factory+Port.swift
@@ -1,0 +1,16 @@
+import Foundation
+import MyNameIsURL
+
+
+
+extension Factory {
+  enum Port {
+    static let success = MyNameIsURL.Port(80)
+    static let failures = [
+      MyNameIsURL.Port(443),
+      MyNameIsURL.Port(800),
+      MyNameIsURL.Port(-80),
+      MyNameIsURL.Port.missing,
+    ]
+  }
+}

--- a/Tests/MyNameIsURLTests/Support/Factory+User.swift
+++ b/Tests/MyNameIsURLTests/Support/Factory+User.swift
@@ -1,0 +1,22 @@
+import Foundation
+import MyNameIsURL
+
+
+extension Factory {
+  enum User {
+    static let success = MyNameIsURL.User("please")
+    
+    static let failures = [
+      MyNameIsURL.User(":"),
+      MyNameIsURL.User("@"),
+      MyNameIsURL.User("please:"),
+      MyNameIsURL.User("please@"),
+      MyNameIsURL.User(":please"),
+      MyNameIsURL.User("@please"),
+      MyNameIsURL.User(" "),
+      MyNameIsURL.User(""),
+      MyNameIsURL.User(" please"),
+      MyNameIsURL.User("please "),
+    ]
+  }
+}

--- a/Tests/MyNameIsURLTests/Support/Factory.swift
+++ b/Tests/MyNameIsURLTests/Support/Factory.swift
@@ -3,6 +3,6 @@ import MyNameIsURL
 
 
 enum Factory {
-  static let url = URL(string: "http://www.example.com/foo/bar")!
+  static let url = URL(string: "http://please:don't@www.example.com:80/foo/bar")!
   static let nilURL = URL(string: "//")!
 }

--- a/Tests/MyNameIsURLTests/UserTests.swift
+++ b/Tests/MyNameIsURLTests/UserTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+import MyNameIsURL
+
+
+
+class UserTests: XCTestCase {
+  func testSuccess() {
+    XCTAssert(Factory.User.success.matches(url: Factory.url))
+    XCTAssertFalse(Factory.User.success.matches(url: Factory.nilURL))
+  }
+  
+  
+  func testNil() {
+    XCTAssertFalse(User.missing.matches(url: Factory.url))
+    XCTAssert(User.missing.matches(url: Factory.nilURL))
+  }
+  
+  
+  func testFailure() {
+    Factory.User.failures.forEach {
+      XCTAssertFalse($0.matches(url: Factory.url))
+      XCTAssertFalse($0.matches(url: Factory.nilURL))
+    }
+  }
+  
+  
+  func testBlankUserURLs() {
+    [
+      URL(string: "http://@example.com")!,
+      URL(string: "http://:@example.com")!,
+    ].forEach {
+      XCTAssertFalse(User.missing.matches(url: $0))
+      XCTAssert(User("").matches(url: $0))
+    }
+  }
+  
+  
+  func testUserWithMissingOrPasswordStillWorks() {
+    [
+      URL(string: "http://someone:@example.com")!,
+      URL(string: "http://someone@example.com")!,
+    ].forEach {
+      XCTAssertFalse(User.missing.matches(url: $0))
+      XCTAssert(User("someone").matches(url: $0))
+    }
+  }
+}
+


### PR DESCRIPTION
Also adds matchers for `Port`, `User`, and `Password` (each of which is, not coincidentally, usually missing from URLs).