### PR TITLE
Adds wildcard type, matching, and tests.

### DIFF
--- a/Sources/MyNameIsURL/Matchers/PathPrefix.swift
+++ b/Sources/MyNameIsURL/Matchers/PathPrefix.swift
@@ -8,14 +8,14 @@ import Foundation
  Usage:
  ```
  let url = URL(string: "http://example.com/foo/bar")!
- Path(["/", "foo", "bar"]).matches(url) //> true
- Path(["/", "foo"]).matches(url)        //> true
+ PathPrefix(["/", "foo", "bar"]).matches(url) //> true
+ PathPrefix(["/", "foo"]).matches(url)        //> true
  ```
  
  - SeeAlso: `Path`
  */
 public struct PathPrefix: URLMatchable {
-  private let pathComponents: [String]
+  private let pathComponents: [PathComponent]
 
 
   /**
@@ -33,7 +33,7 @@ public struct PathPrefix: URLMatchable {
    
      In the common case of matching against an absolute `URL`, don’t forget the first element of path components must be a `"/"`.
    */
-  public init(_ pathComponents: [String]) {
+  public init(_ pathComponents: [PathComponent]) {
     self.pathComponents = pathComponents
   }
 
@@ -46,6 +46,17 @@ public struct PathPrefix: URLMatchable {
    */
   public func matches(url: URL) -> Bool {
     let pathPrefix = url.pathComponents.prefix(pathComponents.count)
-    return pathComponents == Array(pathPrefix)
+    guard pathPrefix.count == pathComponents.count else {
+      return false
+    }
+    
+    return zip(pathPrefix, pathComponents).allSatisfy { prefix, component in
+      switch component {
+      case .name(let name):
+        return prefix == name
+      case .wildcard:
+        return true
+      }
+    }
   }
 }

--- a/Sources/MyNameIsURL/Types/PathComponent.swift
+++ b/Sources/MyNameIsURL/Types/PathComponent.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+
+
+public extension PathPrefix {
+  /**
+   Represents a path component for use in creating a `PathPrefix`. A path component can be either a `name` (which is matched for equality with the strings of a `URL`’s `pathComponents`) or a `wildcard` (which matches any non-nil value):
+   
+   ```
+   PathPrefix([.name("/"), .wildcard, .name("bar")])
+   ```
+   
+   To reduce noise, `PathComponent` conforms to `ExpressibleByStringLiteral`. So the above can be more simply expressed as:
+   
+   ```
+   PathPrefix(["/", .wildcard, "foo"])
+   ```
+   
+   - SeeAlso: `PathPrefix`
+   */
+  enum PathComponent {
+    /// A path component that matches other path components by string comparison.
+    case name(String)
+    /// A path component that matches any non-nil path component.
+    case wildcard
+  }
+}
+
+
+
+extension PathPrefix.PathComponent: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self = .name(value)
+  }
+}

--- a/Support/MyNameIsURL.xcodeproj/project.pbxproj
+++ b/Support/MyNameIsURL.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		C1AE2755230DA84B0099C39C /* Port.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AE2754230DA84B0099C39C /* Port.swift */; };
 		C1AE2757230DA9E10099C39C /* PortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AE2756230DA9E10099C39C /* PortTests.swift */; };
 		C1AE2759230DAA310099C39C /* Factory+Port.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AE2758230DAA310099C39C /* Factory+Port.swift */; };
+		C1D1CDF423182E89007349B4 /* PathComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D1CDF323182E89007349B4 /* PathComponent.swift */; };
 		OBJ_21 /* URLMatchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* URLMatchable.swift */; };
 		OBJ_28 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_41 /* MyNameIsURL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "MyNameIsURL::MyNameIsURL::Product" /* MyNameIsURL.framework */; };
@@ -122,6 +123,7 @@
 		C1AE2754230DA84B0099C39C /* Port.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Port.swift; sourceTree = "<group>"; };
 		C1AE2756230DA9E10099C39C /* PortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortTests.swift; sourceTree = "<group>"; };
 		C1AE2758230DAA310099C39C /* Factory+Port.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Factory+Port.swift"; sourceTree = "<group>"; };
+		C1D1CDF323182E89007349B4 /* PathComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathComponent.swift; sourceTree = "<group>"; };
 		"MyNameIsURL::MyNameIsURL::Product" /* MyNameIsURL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MyNameIsURL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"MyNameIsURL::MyNameIsURLTests::Product" /* MyNameIsURLTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = MyNameIsURLTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 			children = (
 				C110EC4422CD9BC4007FF845 /* Scheme.swift */,
 				C110EC1A22CD08D6007FF845 /* Domain.swift */,
+				C1D1CDF323182E89007349B4 /* PathComponent.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -367,6 +370,7 @@
 				C110EC2922CD1268007FF845 /* HostSuffix.swift in Sources */,
 				C110EC2E22CD13C8007FF845 /* PathPrefix.swift in Sources */,
 				C190154722E2253F00FADA9D /* Scheme+URLMatchable.swift in Sources */,
+				C1D1CDF423182E89007349B4 /* PathComponent.swift in Sources */,
 				C1A0E64823109DF600339C86 /* Password.swift in Sources */,
 				C110EC1B22CD08D6007FF845 /* Domain.swift in Sources */,
 				C110EC2422CD0D05007FF845 /* Host.swift in Sources */,

--- a/Tests/MyNameIsURLTests/PathPrefixTests.swift
+++ b/Tests/MyNameIsURLTests/PathPrefixTests.swift
@@ -26,4 +26,26 @@ class PathPrefixTests: XCTestCase {
     }
     wait(for: [ran], timeout: 0)
   }
+  
+  
+  func testWildcardSuccess() {
+    let ran = expectation(description: "Loop ran.")
+    ran.assertForOverFulfill = false
+    Factory.PathPrefix.Wildcard.succeeding.forEach {
+      XCTAssert($0.matches(url: Factory.PathPrefix.Wildcard.url))
+      ran.fulfill()
+    }
+    wait(for: [ran], timeout: 0)
+  }
+  
+  
+  func testWildcardFailure() {
+    let ran = expectation(description: "Loop ran.")
+    ran.assertForOverFulfill = false
+    Factory.PathPrefix.Wildcard.failing.forEach {
+      XCTAssertFalse($0.matches(url: Factory.PathPrefix.Wildcard.url))
+      ran.fulfill()
+    }
+    wait(for: [ran], timeout: 0)
+  }
 }

--- a/Tests/MyNameIsURLTests/Support/Factory+PathPrefix.swift
+++ b/Tests/MyNameIsURLTests/Support/Factory+PathPrefix.swift
@@ -5,6 +5,39 @@ import MyNameIsURL
 
 extension Factory {
   enum PathPrefix {
+    enum Wildcard {
+      static let url = URL(string: "http://example.com/foo/bar/baz/thud")!
+      
+      static let succeeding = [
+        // Wildcards replace a single path component:
+        MyNameIsURL.PathPrefix(["/", .wildcard, "bar", "baz", "thud"]),
+        MyNameIsURL.PathPrefix(["/", "foo", .wildcard, "baz", "thud"]),
+        MyNameIsURL.PathPrefix(["/", "foo", "bar", .wildcard, "thud"]),
+        MyNameIsURL.PathPrefix(["/", "foo", "bar", "baz", .wildcard]),
+        
+        // Wildcards are still prefixes:
+        MyNameIsURL.PathPrefix(["/", .wildcard, "bar"]),
+        MyNameIsURL.PathPrefix(["/", .wildcard, .wildcard, "baz"]),
+        MyNameIsURL.PathPrefix(["/", .wildcard, .wildcard, .wildcard, "thud"]),
+        
+        // Unbounded wildcards are meaningless, but still work:
+        MyNameIsURL.PathPrefix(["/", .wildcard]),
+        MyNameIsURL.PathPrefix(["/", .wildcard, .wildcard]),
+        MyNameIsURL.PathPrefix(["/", .wildcard, .wildcard, .wildcard]),
+        MyNameIsURL.PathPrefix(["/", .wildcard, .wildcard, .wildcard, .wildcard]),
+      ]
+      
+      static let failing = [
+        // Wildcards with wrong anchors sill fail:
+        MyNameIsURL.PathPrefix(["/", "fuzz", .wildcard]),
+        MyNameIsURL.PathPrefix(["/", .wildcard, "fuzz"]),
+        
+        // Wilcards only match a single component
+        MyNameIsURL.PathPrefix(["/", .wildcard, "baz"]),
+        MyNameIsURL.PathPrefix(["/", "foo", .wildcard, "thud"]),
+        MyNameIsURL.PathPrefix(["/", .wildcard, "thud"]),
+      ]
+    }
     static let failing = [
       MyNameIsURL.PathPrefix(["foo"]),
       MyNameIsURL.PathPrefix(["bar"]),


### PR DESCRIPTION
Allows wildcards to be specified in path prefix matchers like so:

```swift
let url = URL(string: "http://example.com/foo/bar")!
PathPrefix(["/", .wildcard, "bar"]).matches(url: url) //> true
```

**_Note this is source-compatible with previous versions but will break binary compatibility due to the addition of `PathPrefix.PathComponent`._**